### PR TITLE
Fixes #38 - Ensures that the attachment data is cleared after save.

### DIFF
--- a/WhisperNote/src/app.js
+++ b/WhisperNote/src/app.js
@@ -44,6 +44,7 @@ SCA.encrypt = function() {
 SCA.encryptWithFile = function(arrayBuffer, filename) {
     if (this.encryptAndEmbedData(arrayBuffer, filename)) {
         this.saveDocument();
+    	this.e('file').value = "";
         this.doOnload();
     }
 };


### PR DESCRIPTION
Appears to work on both Chromium 41.0.2272.76 and Firefox 38.0
